### PR TITLE
Gcleary fix id6

### DIFF
--- a/el.proto
+++ b/el.proto
@@ -88,7 +88,7 @@ message Cell {
     uint32 id3_plus_1 = 4;
     uint64 id4_plus_1 = 5;
     uint32 id5_plus_1 = 6;
-    uint32 id6_plus_1 = 7;
+    uint64 id6_plus_1 = 7;
     bool connected = 8;  // True-device is connected to this cell
     uint32 neg_rssi = 9; // -rssi
     uint32 age = 10;


### PR DESCRIPTION
This fix is optional as (we have discussed) protobuf type int32 is in fact 64 bit. But it is ugly and worth updating sometime.